### PR TITLE
[WiFi Driver] Initial Implementation

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,7 @@ lib_deps =
 	adafruit/Adafruit SSD1306 @ ^2.5.11
 	thomasfredericks/Bounce2@^2.72
 	bodmer/TFT_eSPI @ ^2.5.43
+	http://github.com/tzapu/WiFiManager.git@2.0.17
 
 build_flags = 
 	-DDISPLAY_ADDR=0x3C

--- a/src/utils/core.h
+++ b/src/utils/core.h
@@ -1,0 +1,15 @@
+/******************************************************************************
+ * Project: Klic Smart Irrigation System
+ *
+ * Description:
+ * Core utils library to hold any non-specifics utils that can be shared
+ * in other utils/drivers.
+ *
+ * License:
+ *    This project is open for use, modification, and distribution for personal
+ *    or educational purposes only. Commercial use is strictly prohibited
+ *    without explicit permission from the author
+ ******************************************************************************/
+#pragma once
+
+#define ARRAY_SIZE(__arr) (sizeof(__arr) / sizeof(__arr[0]))

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -1,0 +1,226 @@
+/******************************************************************************
+ * Project: Klic Smart Irrigation System
+ *
+ * Description:
+ * Logger implementation to print to a `Print` object using several logger
+ * levels
+ *
+ * License:
+ *    This project is open for use, modification, and distribution for personal
+ *    or educational purposes only. Commercial use is strictly prohibited
+ *    without explicit permission from the author
+ ******************************************************************************/
+#include "logger.h"
+#include "core.h"
+#include <Arduino.h>
+
+// Local macro for prefix debug msg
+#define LOG_DEBUG_PREFIX_MSG "[\033[1m\033[35mDEBUG\033[0m]: "
+// Local macro for prefix info msg
+#define LOG_INFO_PREFIX_MSG "[\033[1m\033[32mINFO \033[0m]: "
+// Local macro for prefix warn msg
+#define LOG_WARN_PREFIX_MSG "[\033[1m\033[93mWARN \033[0m]: "
+// Local macro for prefix error msg
+#define LOG_ERROR_PREFIX_MSG "[\033[1m\033[91mERROR\033[0m]: "
+
+const char *LogLevelStrMap[] = {
+    LOG_DEBUG_PREFIX_MSG,
+    LOG_INFO_PREFIX_MSG,
+    LOG_WARN_PREFIX_MSG,
+    LOG_ERROR_PREFIX_MSG,
+    "[     ]: "
+};
+
+const char *ColorAnsiCodeStr[] = {
+    "\033[1m",
+    "\033[93m",
+    "\033[91m",
+    "\033[32m",
+    "\033[0m"
+};
+
+const char *GetStringLogLevel(eLogLevel_t log_lv)
+{
+    if (log_lv >= ARRAY_SIZE(LogLevelStrMap)) {
+        return "[UNKNO]: ";
+    }
+    return LogLevelStrMap[(uint8_t)log_lv];
+}
+
+size_t SysLogger::write(const uint8_t *buffer, size_t size)
+{
+    if (this->cout != nullptr)
+        return this->cout->write(buffer, size);
+    return 0;
+}
+
+size_t SysLogger::write(uint8_t _byte)
+{
+    if (this->cout != nullptr)
+        return this->cout->write(_byte);
+    return 0;
+}
+
+SysLogger &SysLogger::operator<<(LoggerIntBase_e base)
+{
+    this->intBase = base;
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(LoggerFormatText_e ansiCode)
+{
+    if (ansiCode < ARRAY_SIZE(ColorAnsiCodeStr)) {
+        (*this) << ColorAnsiCodeStr[ansiCode];
+    }
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(LoggerSpecialChar_t specialChar)
+{
+    switch (specialChar)
+    {
+    case EndLine:
+        (*this) << LOGGER_TEXT_RESET << F("\n\r");
+        break;
+    }
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(eLogLevel_t lvl)
+{
+    this->canLog = lvl >= this->log_lvl;
+    (*this) << LOGGER_TEXT_RESET << GetStringLogLevel(lvl);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(const __FlashStringHelper *msg)
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(const String &msg)
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(const char msg[])
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(char msg)
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(unsigned char msg)
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg, (uint8_t)intBase);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(int msg)
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(unsigned int msg)
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(long msg)
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(unsigned long msg)
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(double msg)
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg);
+    return *this;
+}
+
+SysLogger &SysLogger::operator<<(const Printable &msg)
+{
+    if (canLog && this->cout != nullptr)
+        this->cout->print(msg);
+    return *this;
+}
+
+void SysLogger::log(const __FlashStringHelper *msg, eLogLevel_t lvl)
+{
+    (*this) << lvl << msg << EndLine;
+}
+
+void SysLogger::log(const String &msg, eLogLevel_t lvl)
+{
+    (*this) << lvl << msg << EndLine;
+}
+
+void SysLogger::log(const char msg[], eLogLevel_t lvl)
+{
+    (*this) << lvl << msg << EndLine;
+}
+
+void SysLogger::log(char msg, eLogLevel_t lvl)
+{
+    (*this) << lvl << msg << EndLine;
+}
+
+void SysLogger::log(unsigned char msg, eLogLevel_t lvl, int base)
+{
+    (*this) << lvl << msg << EndLine;
+}
+
+void SysLogger::log(int msg, eLogLevel_t lvl, int base)
+{
+    (*this) << lvl << msg << EndLine;
+}
+
+void SysLogger::log(unsigned int msg, eLogLevel_t lvl, int base)
+{
+    (*this) << lvl << msg << EndLine;
+}
+
+void SysLogger::log(long msg, eLogLevel_t lvl, int base)
+{
+    (*this) << lvl << msg << EndLine;
+}
+
+void SysLogger::log(unsigned long msg, eLogLevel_t lvl, int base)
+{
+    (*this) << lvl << msg << EndLine;
+}
+
+void SysLogger::log(double msg, eLogLevel_t lvl, int precision)
+{
+    (*this) << lvl << msg << EndLine;
+}
+
+void SysLogger::log(const Printable &msg, eLogLevel_t lvl)
+{
+    (*this) << lvl << msg << EndLine;
+}

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -1,0 +1,108 @@
+/******************************************************************************
+ * Project: Klic Smart Irrigation System
+ *
+ * Description:
+ * Logger implementation to print to a `Print` object using several logger
+ * levels
+ *
+ * License:
+ *    This project is open for use, modification, and distribution for personal
+ *    or educational purposes only. Commercial use is strictly prohibited
+ *    without explicit permission from the author
+ ******************************************************************************/
+#pragma once
+
+#include <Print.h>
+
+typedef enum
+{
+    // Log at debug level
+    LOG_DEBUG,
+    // Log at info level
+    LOG_INFO,
+    // Log at warning level
+    LOG_WARN,
+    // Log at error level
+    LOG_ERROR,
+    // Log at any level
+    LOG_MASTER
+} eLogLevel_t;
+
+typedef enum
+{
+    EndLine
+} LoggerSpecialChar_t;
+
+typedef enum
+{
+    LOGGER_TEXT_BOLD,
+    LOGGER_TEXT_YELLOW,
+    LOGGER_TEXT_RED,
+    LOGGER_TEXT_GREEN,
+    LOGGER_TEXT_RESET
+} LoggerFormatText_e;
+
+typedef enum
+{
+    INT_BIN = 2,
+    INT_OCT = 8,
+    INT_DEC = 10,
+    INT_HEX = 16
+} LoggerIntBase_e;
+
+const char *GetStringLogLevel(eLogLevel_t);
+
+class SysLogger : public Print
+{
+    eLogLevel_t log_lvl;
+    Print *cout;
+    bool canLog = false;
+    LoggerIntBase_e intBase;
+
+public:
+    SysLogger(Print *printOut)
+        : cout(printOut), intBase(INT_DEC)
+    {
+    }
+
+    void setLogOutput (Print *printOut)
+    {
+        this->cout = printOut;
+    }
+
+    size_t write(const uint8_t *buffer, size_t size);
+    size_t write(uint8_t _byte);
+
+    eLogLevel_t logLevel() const { return this->log_lvl; }
+    void setLogLevel(const eLogLevel_t &_lvl) { this->log_lvl = _lvl; }
+
+    SysLogger &operator<<(LoggerIntBase_e);
+    SysLogger &operator<<(LoggerFormatText_e);
+    SysLogger &operator<<(LoggerSpecialChar_t);
+    SysLogger &operator<<(eLogLevel_t);
+    SysLogger &operator<<(const __FlashStringHelper *);
+    SysLogger &operator<<(const String &);
+    SysLogger &operator<<(const char[]);
+    SysLogger &operator<<(char);
+    SysLogger &operator<<(unsigned char);
+    SysLogger &operator<<(int);
+    SysLogger &operator<<(unsigned int);
+    SysLogger &operator<<(long);
+    SysLogger &operator<<(unsigned long);
+    SysLogger &operator<<(double);
+    SysLogger &operator<<(const Printable &);
+
+    void log(const __FlashStringHelper *, eLogLevel_t);
+    void log(const String &, eLogLevel_t);
+    void log(const char[], eLogLevel_t);
+    void log(char, eLogLevel_t);
+    void log(unsigned char, eLogLevel_t, int = DEC);
+    void log(int, eLogLevel_t, int = DEC);
+    void log(unsigned int, eLogLevel_t, int = DEC);
+    void log(long, eLogLevel_t, int = DEC);
+    void log(unsigned long, eLogLevel_t, int = DEC);
+    void log(double, eLogLevel_t, int = 2);
+    void log(const Printable &, eLogLevel_t);
+};
+
+extern SysLogger logger;

--- a/src/wifi/WiFiDriver.cpp
+++ b/src/wifi/WiFiDriver.cpp
@@ -1,0 +1,56 @@
+/******************************************************************************
+ * Project: Klic Smart Irrigation System
+ *
+ * Description:
+ * Library intended to initialize the WiFi drivers for an Arduino-based ESP32
+ * CPU
+ *
+ * License:
+ *    This project is open for use, modification, and distribution for personal
+ *    or educational purposes only. Commercial use is strictly prohibited
+ *    without explicit permission from the author
+ ******************************************************************************/
+#include "WiFiDriver.h"
+
+#include "utils/logger.h"
+
+void _configureWiFiManager() {
+  WiFiDriver::_wm.setConnectTimeout(120);
+  WiFiDriver::_wm.setConfigPortalTimeout(180);
+}
+
+namespace WiFiDriver {
+
+// Namespace extern definitions
+namespace Config {
+const char* WIFI_SSID = "KLIC-ISFAB2";
+const char* WIFI_PASS = "ROOT";
+}  // namespace Config
+
+WiFiManager _wm;
+
+// Exposed methods
+
+bool WiFiInitialize(void) {
+  WiFi.mode(WIFI_STA);
+  _configureWiFiManager();
+
+  // will try to connect when it has saved credentials
+  // if it fails will start the access point
+  bool connected = WiFiDriver::_wm.autoConnect(WiFiDriver::Config::WIFI_SSID,
+                                               WiFiDriver::Config::WIFI_PASS);
+  if (!connected) {
+    logger << LOG_ERROR << "WiFi AutoConnect failed to: "
+           << WiFiDriver::_wm.getWiFiSSID(false)
+           << " with pass: " << WiFiDriver::_wm.getWiFiPass(false) << EndLine;
+    return false;
+  }
+
+  logger << LOG_INFO << "WiFi AutoConnect done! IP: " << WiFi.localIP()
+         << EndLine;
+
+  return true;
+}
+
+}  // namespace WiFiDriver
+

--- a/src/wifi/WiFiDriver.h
+++ b/src/wifi/WiFiDriver.h
@@ -1,0 +1,42 @@
+/******************************************************************************
+ * Project: Klic Smart Irrigation System
+ *
+ * Description:
+ * Library intended to initialize the WiFi drivers for an Arduino-based ESP32
+ * CPU
+ *
+ * License:
+ *    This project is open for use, modification, and distribution for personal
+ *    or educational purposes only. Commercial use is strictly prohibited
+ *    without explicit permission from the author
+ ******************************************************************************/
+#pragma once
+
+#include "WiFiManager.h"
+
+namespace WiFiDriver {
+
+/**
+ * @brief WiFi Configurations.
+ */
+namespace Config {
+/**
+ * Specifies the ESP32 host wifi ssid.
+ */
+extern const char* WIFI_SSID;
+/**
+ * Specifies the ESP32 host wifi pass.
+ */
+extern const char* WIFI_PASS;
+}  // namespace Config
+
+
+extern WiFiManager _wm;
+
+/**
+ * @brief Initialize WIFI interface using the specified configuration.
+ *
+ * @return bool   WiFi status code.
+ */
+bool WiFiInitialize(void);
+}  // namespace WiFiDriver


### PR DESCRIPTION
## Summary of changes

Implemented a new namespace `WiFiDriver::WiFiInitialize` method that starts using the `WiFiManager` library to initialize our device as HOST to get setup and credentials to connect to an internet spot.

> [!NOTE]
> I added two utility headers, `logger.h`, that exposes a singleton class to facilitate using the logger and different log levels for the application.
> And `core.h` for shared utils that can be exposed in a generic header.